### PR TITLE
feat: Add span support to parser

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -30,6 +30,8 @@ pub enum TypeSpecifier {
     Optional,
 }
 
+use crate::parser::Span;
+
 #[derive(Debug, PartialEq)]
 #[allow(dead_code)]
 pub struct Program {
@@ -37,7 +39,13 @@ pub struct Program {
 }
 
 #[derive(Debug, PartialEq)]
-pub enum Statement {
+pub struct Statement {
+    pub kind: StatementKind,
+    pub span: Span,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum StatementKind {
     Variable(VariableStatement),
     Function(FunctionDefinition),
     ValueType(ValueTypeDeclaration),
@@ -94,7 +102,14 @@ pub struct VariableStatement {
 
 #[derive(Debug, PartialEq)]
 #[allow(dead_code)]
-pub enum Expression {
+pub struct Expression {
+    pub kind: ExpressionKind,
+    pub span: Span,
+}
+
+#[derive(Debug, PartialEq)]
+#[allow(dead_code)]
+pub enum ExpressionKind {
     Literal(Literal),
     Binary(Box<Expression>, BinaryOperator, Box<Expression>),
     Unary(UnaryOperator, Box<Expression>),


### PR DESCRIPTION
This commit introduces span (start and end character offsets) support to the parser and AST.

- The `Token` enum has been refactored into a `Token` struct containing a `TokenKind` enum and a `Span`.
- The `Statement` and `Expression` enums in the AST have been refactored into structs containing a `Kind` enum and a `Span`.
- The parser has been updated to calculate and propagate these spans for all AST nodes.
- Tests have been updated to verify the correctness of the spans.