### PR TITLE
Feat: Add line and column numbers to error reporting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,33 @@ mod parser;
 
 use parser::{Lexer, Parser};
 
+fn report_error(input: &str, line_starts: &[usize], error: parser::Error) {
+    let line = line_starts
+        .iter()
+        .rposition(|&s| s <= error.span.start)
+        .unwrap_or(0);
+    let col = error.span.start - line_starts[line];
+    println!(
+        "Error: {} at line {}, column {}",
+        error.message,
+        line + 1,
+        col + 1
+    );
+    let line_str = input.lines().nth(line).unwrap_or("");
+    println!("{}", line_str);
+    for _ in 0..col {
+        print!(" ");
+    }
+    println!("^");
+}
+
 fn main() {
-    let input = "1 + 2 * 3";
+    let input = "1 + 2 * ";
     let lexer = Lexer::new(input);
+    let line_starts = lexer.line_starts.clone();
     let mut parser = Parser::new(lexer);
     match parser.parse_expression() {
         Ok(expr) => println!("{:?}", expr),
-        Err(e) => println!("Error: {}", e),
+        Err(e) => report_error(input, &line_starts, e),
     }
 }


### PR DESCRIPTION
This commit introduces line and column numbers to the error reporting, making it easier for users to locate errors in their code.

The changes include:
- The `Lexer` now keeps track of the starting position of each line.
- The `Parser` now returns a new `Error` struct that includes a `Span` with the location of the error.
- The `main` function now includes a `report_error` function that formats the error message with the line and column number, and prints the line with a caret pointing to the error.