### PR TITLE
feat: Update array expression to support sized literals

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -189,8 +189,12 @@ pub struct FunctionCall {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct ArrayLiteral {
-    pub elements: Vec<Expression>,
+pub enum ArrayLiteral {
+    List(Vec<Expression>),
+    Sized {
+        value: Box<Expression>,
+        size: Box<Expression>,
+    },
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -42,6 +42,7 @@ pub enum TokenKind {
     RBrace,
     RBracket,
     RParen,
+    Semicolon,
     LBracket,
     Slash,
 
@@ -179,6 +180,7 @@ impl<'a> Lexer<'a> {
             b'{' => TokenKind::LBrace,
             b'}' => TokenKind::RBrace,
             b':' => TokenKind::Colon,
+            b';' => TokenKind::Semicolon,
             b',' => TokenKind::Comma,
             b'"' => {
                 let kind = self.read_string();

--- a/src/parser_array_tests.rs
+++ b/src/parser_array_tests.rs
@@ -22,11 +22,35 @@ fn test_parse_array_type() {
                 }))),
             })),
             value: Expression {
-                kind: ExpressionKind::ArrayLiteral(Box::new(ArrayLiteral { elements: vec![] })),
+                kind: ExpressionKind::ArrayLiteral(Box::new(ArrayLiteral::List(vec![]))),
                 span: Span { start: 15, end: 17 },
             },
         }),
         span: Span { start: 0, end: 17 },
+    };
+    assert_eq!(parser.parse_statement(), Ok(expected));
+}
+
+#[test]
+fn test_parse_sized_array_literal() {
+    let input = "[1; 5]";
+    let lexer = Lexer::new(input);
+    let mut parser = Parser::new(lexer);
+    let expected = Statement {
+        kind: StatementKind::Expression(Expression {
+            kind: ExpressionKind::ArrayLiteral(Box::new(ArrayLiteral::Sized {
+                value: Box::new(Expression {
+                    kind: ExpressionKind::Literal(Literal::Integer(1)),
+                    span: Span { start: 1, end: 2 },
+                }),
+                size: Box::new(Expression {
+                    kind: ExpressionKind::Literal(Literal::Integer(5)),
+                    span: Span { start: 4, end: 5 },
+                }),
+            })),
+            span: Span { start: 0, end: 6 },
+        }),
+        span: Span { start: 0, end: 6 },
     };
     assert_eq!(parser.parse_statement(), Ok(expected));
 }
@@ -48,7 +72,7 @@ fn test_parse_multidimensional_array_type() {
                 }))),
             })),
             value: Expression {
-                kind: ExpressionKind::ArrayLiteral(Box::new(ArrayLiteral { elements: vec![] })),
+                kind: ExpressionKind::ArrayLiteral(Box::new(ArrayLiteral::List(vec![]))),
                 span: Span { start: 17, end: 19 },
             },
         }),
@@ -64,22 +88,20 @@ fn test_parse_array_literal() {
     let mut parser = Parser::new(lexer);
     let expected = Statement {
         kind: StatementKind::Expression(Expression {
-            kind: ExpressionKind::ArrayLiteral(Box::new(ArrayLiteral {
-                elements: vec![
-                    Expression {
-                        kind: ExpressionKind::Literal(Literal::Integer(1)),
-                        span: Span { start: 1, end: 2 },
-                    },
-                    Expression {
-                        kind: ExpressionKind::Literal(Literal::Integer(2)),
-                        span: Span { start: 4, end: 5 },
-                    },
-                    Expression {
-                        kind: ExpressionKind::Literal(Literal::Integer(3)),
-                        span: Span { start: 7, end: 8 },
-                    },
-                ],
-            })),
+            kind: ExpressionKind::ArrayLiteral(Box::new(ArrayLiteral::List(vec![
+                Expression {
+                    kind: ExpressionKind::Literal(Literal::Integer(1)),
+                    span: Span { start: 1, end: 2 },
+                },
+                Expression {
+                    kind: ExpressionKind::Literal(Literal::Integer(2)),
+                    span: Span { start: 4, end: 5 },
+                },
+                Expression {
+                    kind: ExpressionKind::Literal(Literal::Integer(3)),
+                    span: Span { start: 7, end: 8 },
+                },
+            ]))),
             span: Span { start: 0, end: 9 },
         }),
         span: Span { start: 0, end: 9 },


### PR DESCRIPTION
This commit updates the array expression parsing to support the `[<value>; <size>]` syntax, which creates an array of a given size with all values equal to the provided value.

The changes include:
- Updating the `ArrayLiteral` AST node to be an enum that can represent both a list of elements and a sized array.
- Adding a `Semicolon` token to the lexer.
- Modifying the parser to handle the new syntax.
- Adding a new test case to verify the new syntax is parsed correctly and updating existing tests.