### PR TITLE
docs: Update README.md to include array syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ Dyego is an expression-based language. The following constructs are expressions:
 -   **If-Else**: `if <condition> { <then_branch> } else { <else_branch> }`
 -   **When**: `when <expression> { <condition> => <result>, ... }`
 -   **Blocks**: `{ <statement>* <expression>? }`
+-   **Array Literals**: `[<element1>, <element2>, ...]` or `[<value>; <size>]`
 
 ### Types
 
 -   **Simple Types**: `i32`, `f64`, or any user-defined type.
 -   **Tuple Types**: `(<type>, <type>, ...)`
+-   **Array Types**: `T[]` (where `T` is any type)
 
 ### Parameters and Fields
 


### PR DESCRIPTION
Adds documentation for array literals and array types to the README.md file. This reflects the recent changes to the parser to support array expressions.