### PR TITLE
Feat: Change lambda expression syntax to be Kotlin-like

### DIFF
--- a/src/parser_lambda_tests.rs
+++ b/src/parser_lambda_tests.rs
@@ -6,7 +6,7 @@ use crate::{
 
 #[test]
 fn test_lambda_expression() {
-    let input = "fn(x: int, y: int) -> int { x + y }";
+    let input = "{ x: int, y: int -> x + y } -> int";
     let l = Lexer::new(input);
     let mut p = Parser::new(l);
     let expr = p.parse_expression().unwrap();
@@ -82,7 +82,7 @@ fn test_function_type() {
 
 #[test]
 fn test_variable_declaration_with_lambda() {
-    let input = "val add = fn(x: int, y: int) -> int { x + y }";
+    let input = "val add = { x: int, y: int -> x + y } -> int";
     let l = Lexer::new(input);
     let mut p = Parser::new(l);
     let stmt = p.parse_statement().unwrap();
@@ -104,7 +104,7 @@ fn test_variable_declaration_with_lambda() {
 
 #[test]
 fn test_variable_declaration_with_function_type() {
-    let input = "val add: fn(int, int) -> int = fn(x: int, y: int) -> int { x + y }";
+    let input = "val add: fn(int, int) -> int = { x: int, y: int -> x + y } -> int";
     let l = Lexer::new(input);
     let mut p = Parser::new(l);
     let stmt = p.parse_statement().unwrap();


### PR DESCRIPTION
This commit changes the syntax for lambda expressions to be more similar to Kotlin's syntax.

The old syntax was:
`fn(<parameter list>) [-> <return type>] { <body> }`

The new syntax is:
`{ <parameter list> -> <body> } [-> <return type>]`

The key changes are:
- Lambdas now start with `{` instead of `fn (`.
- The parameter list is no longer enclosed in parentheses.
- The parameter list is separated from the body by an arrow `->`.
- The optional return type annotation now comes after the closing brace `}` of the body.

To achieve this, the following changes were made:
- The parser now has lookahead capability to distinguish between a lambda and a block.
- The `parse_lambda_expression` function was rewritten to support the new syntax.
- A new helper function `parse_lambda_parameters` was introduced.
- The lambda-related tests were updated to use the new syntax.

The syntax for function types (e.g., `fn(i32) -> i32`) remains unchanged.