### PR TITLE
refactor: Replace 'fn' with 'fun' for function types

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -50,7 +50,6 @@ pub enum TokenKind {
     // Reserved words
     Else,
     Eof,
-    Fn,
     For,
     Fun,
     If,
@@ -279,7 +278,6 @@ impl<'a> Lexer<'a> {
             "else" => TokenKind::Else,
             "val" => TokenKind::Val,
             "var" => TokenKind::Var,
-            "fn" => TokenKind::Fn,
             "fun" => TokenKind::Fun,
             "value" => TokenKind::Value,
             "object" => TokenKind::Object,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -383,7 +383,7 @@ impl<'a> Parser<'a> {
             self.parse_tuple_type()?
         } else {
             let base_type = match self.current_token.kind.clone() {
-                TokenKind::Fn => {
+                TokenKind::Fun => {
                     self.next_token();
                     BaseType::Function(self.parse_function_type()?)
                 }
@@ -1076,7 +1076,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    // function_type ::= 'fn' '(' (type (',' type)*)? ')' '->' type
+    // function_type ::= 'fun' '(' (type (',' type)*)? ')' '->' type
     fn parse_function_type(&mut self) -> Result<FunctionType, Error> {
         self.expect_token(TokenKind::LParen)?;
 

--- a/src/parser_lambda_tests.rs
+++ b/src/parser_lambda_tests.rs
@@ -46,7 +46,7 @@ fn test_lambda_expression() {
 
 #[test]
 fn test_function_type() {
-    let input = "fn(int, int) -> int";
+    let input = "fun(int, int) -> int";
     let l = Lexer::new(input);
     let mut p = Parser::new(l);
     let type_ = p.parse_type().unwrap();
@@ -104,7 +104,7 @@ fn test_variable_declaration_with_lambda() {
 
 #[test]
 fn test_variable_declaration_with_function_type() {
-    let input = "val add: fn(int, int) -> int = { x: int, y: int -> x + y } -> int";
+    let input = "val add: fun(int, int) -> int = { x: int, y: int -> x + y } -> int";
     let l = Lexer::new(input);
     let mut p = Parser::new(l);
     let stmt = p.parse_statement().unwrap();


### PR DESCRIPTION
This commit replaces the `fn` keyword with `fun` for defining function types. The `fun` keyword is already used for function declarations, so this change makes the language more consistent.

The following changes were made:
- The `TokenKind::Fn` was removed from the lexer.
- The parser was updated to expect `TokenKind::Fun` when parsing function types.
- The tests for function types were updated to use the `fun` keyword.